### PR TITLE
Fix welding tool refueling by adding missing WeldingTool tags

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/welders.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/welders.yml
@@ -122,6 +122,9 @@
       collection: Welder
     endSound:
       collection: WelderOff
+  - type: Tag
+    tags:
+      - WeldingTool
 
 - type: entity
   name: industrial welding tool
@@ -190,6 +193,9 @@
         Quantity: 1
   - type: RequiresEyeProtection
     statusEffectTime: 5 # less harmful; sunglasses can block it
+  - type: Tag
+    tags:
+      - WeldingTool
 
 - type: entity
   name: emergency welding tool
@@ -217,6 +223,9 @@
     enabled: false
     radius: 1.0
     color: orange
+  - type: Tag
+    tags:
+      - WeldingTool
 
 - type: entity
   parent: [ Welder, BaseXenoborgContraband ]
@@ -235,3 +244,6 @@
       reagents:
       - ReagentId: WeldingFuel
         Quantity: 0.1
+  - type: Tag
+    tags:
+      - WeldingTool


### PR DESCRIPTION
## About the PR
Fixed welding tools being unable to refuel from fuel tanks by adding the missing `WeldingTool` tags required by the fuel tank whitelist system.

## Why / Balance
Welding tools were broken and unable to refuel from fuel tanks, making them unusable once they ran out of fuel. This was caused by the fuel tanks having a whitelist that only allowed entities with the `WeldingTool` tag to refuel from them, but the welding tool prototypes were missing this tag.

This fix restores normal welding tool functionality without changing balance - welders should be refuelable as intended.

## Technical details
- Added `WeldingTool` tag component to all welding tool prototypes:
  - Base Welder (`Welder`)
  - Experimental Welder (`WelderExperimental`) 
  - Emergency Welder (`WelderMini`)
  - Refueling Welder (`RefuelingWelder`)
- Industrial welders inherit the tag from the base welder prototype

The fuel tanks already had the whitelist configured (`fuelWhitelist: tags: - WeldingTool`) but welding tools lacked the required tag to pass the whitelist check in the refueling system.

## Media
N/A - This is a functional fix with no visual changes.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None.

**Changelog**
:cl:
- fix: Fixed welding tools being unable to refuel from fuel tanks
:cl: