### PR TITLE
Add ColoredComponent system for simple entity coloring

### DIFF
--- a/Content.Client/Colored/ColoredVisualizerSystem.cs
+++ b/Content.Client/Colored/ColoredVisualizerSystem.cs
@@ -1,0 +1,158 @@
+using Content.Client.Items.Systems;
+using Content.Shared.Clothing;
+using Content.Shared.Colored;
+using Content.Shared.Hands;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Shared.Prototypes;
+using static Robust.Client.GameObjects.SpriteComponent;
+
+namespace Content.Client.Colored;
+
+public sealed class ColoredVisualizerSystem : VisualizerSystem<ColoredComponent>
+{
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly IPrototypeManager _protoMan = default!;
+    [Dependency] private readonly ItemSystem _itemSystem = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ColoredComponent, ComponentInit>(OnInit);
+        SubscribeLocalEvent<ColoredComponent, ComponentShutdown>(OnShutdown);
+        SubscribeLocalEvent<ColoredComponent, AfterAutoHandleStateEvent>(OnAfterHandleState);
+        SubscribeLocalEvent<ColoredComponent, HeldVisualsUpdatedEvent>(OnHeldVisualsUpdated);
+        SubscribeLocalEvent<ColoredComponent, EquipmentVisualsUpdatedEvent>(OnEquipmentVisualsUpdated);
+    }
+
+    private void OnInit(EntityUid uid, ColoredComponent component, ComponentInit args)
+    {
+        UpdateAppearance(uid, component);
+    }
+
+    private void OnAfterHandleState(EntityUid uid, ColoredComponent component, ref AfterAutoHandleStateEvent args)
+    {
+        UpdateAppearance(uid, component);
+
+        // This is the key! Force refresh of equipment/held visuals
+        // Same approach as ToggleableVisualsSystem
+        _itemSystem.VisualsChanged(uid);
+    }
+
+
+    protected override void OnAppearanceChange(EntityUid uid, ColoredComponent component, ref AppearanceChangeEvent args)
+    {
+        if (args.Sprite == null
+            || !_appearance.TryGetData(uid, ColoredVisuals.Colored, out bool isColored))
+            return;
+
+        if (!isColored)
+            return;
+
+        var shader = _protoMan.Index<ShaderPrototype>(component.ShaderName).Instance();
+        foreach (var spriteLayer in args.Sprite.AllLayers)
+        {
+            if (spriteLayer is not Layer layer)
+                continue;
+
+            if (layer.Shader == null || layer.Shader == shader)
+            {
+                layer.Shader = shader;
+                layer.Color = component.Color;
+            }
+        }
+    }
+
+    private void UpdateAppearance(EntityUid uid, ColoredComponent component, SpriteComponent? sprite = null)
+    {
+        if (!Resolve(uid, ref sprite, false) || !component.Enabled)
+            return;
+
+        if (!_protoMan.TryIndex<ShaderPrototype>(component.ShaderName, out var shaderProto))
+            return;
+
+        var shader = shaderProto.Instance();
+
+        foreach (var spriteLayer in sprite.AllLayers)
+        {
+            if (spriteLayer is not Layer layer)
+                continue;
+
+            // Only apply to layers that don't already have a different shader
+            if (layer.Shader == null || layer.Shader == shader)
+            {
+                layer.Shader = shader;
+                layer.Color = component.Color;
+            }
+        }
+    }
+
+    private void OnShutdown(EntityUid uid, ColoredComponent component, ref ComponentShutdown args)
+    {
+        if (!TryComp(uid, out SpriteComponent? sprite))
+            return;
+
+        if (Terminating(uid))
+            return;
+
+        if (!_protoMan.TryIndex<ShaderPrototype>(component.ShaderName, out var shaderProto))
+            return;
+
+        var shader = shaderProto.Instance();
+
+        // Restore original appearance
+        foreach (var spriteLayer in sprite.AllLayers)
+        {
+            if (spriteLayer is not Layer layer || layer.Shader != shader)
+                continue;
+
+            layer.Shader = null;
+            if (layer.Color == component.Color)
+                layer.Color = component.BeforeColor;
+        }
+    }
+
+    private void OnHeldVisualsUpdated(EntityUid uid, ColoredComponent component, HeldVisualsUpdatedEvent args)
+    {
+        UpdateVisuals(component, args);
+    }
+
+    private void OnEquipmentVisualsUpdated(EntityUid uid, ColoredComponent component, EquipmentVisualsUpdatedEvent args)
+    {
+        UpdateVisuals(component, args);
+    }
+
+    private void UpdateVisuals(ColoredComponent component, EntityEventArgs args)
+    {
+        if (!component.Enabled)
+            return;
+
+        var layers = new HashSet<string>();
+        var entity = EntityUid.Invalid;
+
+        switch (args)
+        {
+            case HeldVisualsUpdatedEvent hgs:
+                layers = hgs.RevealedLayers;
+                entity = hgs.User;
+                break;
+            case EquipmentVisualsUpdatedEvent eqs:
+                layers = eqs.RevealedLayers;
+                entity = eqs.Equipee;
+                break;
+        }
+
+        if (layers.Count == 0 || !TryComp(entity, out SpriteComponent? sprite))
+            return;
+
+        foreach (var revealed in layers)
+        {
+            if (!sprite.LayerMapTryGet(revealed, out var layer))
+                continue;
+
+            sprite.LayerSetShader(layer, component.ShaderName);
+            sprite.LayerSetColor(layer, component.Color);
+        }
+    }
+}

--- a/Content.Server/Colored/ColoredSystem.cs
+++ b/Content.Server/Colored/ColoredSystem.cs
@@ -1,0 +1,72 @@
+using Content.Shared.Colored;
+
+namespace Content.Server.Colored;
+
+public sealed class ColoredSystem : SharedColoredSystem
+{
+    [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ColoredComponent, ComponentStartup>(OnComponentStartup);
+    }
+
+    private void OnComponentStartup(EntityUid uid, ColoredComponent component, ComponentStartup args)
+    {
+        EnsureComp<AppearanceComponent>(uid);
+        UpdateAppearance(uid, component);
+    }
+
+
+
+    public override void UpdateAppearance(EntityUid uid, ColoredComponent? component = null)
+    {
+        if (!Resolve(uid, ref component, false))
+            return;
+
+        _appearance.SetData(uid, ColoredVisuals.Colored, component.Enabled);
+        Dirty(uid, component);
+
+    }
+
+    /// <summary>
+    /// Sets the color of an entity. Creates ColoredComponent if it doesn't exist.
+    /// </summary>
+    public void SetColor(EntityUid uid, Color color, string? shaderName = null)
+    {
+        var component = EnsureComp<ColoredComponent>(uid);
+
+        component.Color = color;
+        if (shaderName != null)
+            component.ShaderName = shaderName;
+
+        Dirty(uid, component);
+        UpdateAppearance(uid, component);
+    }
+
+    /// <summary>
+    /// Removes coloring from an entity
+    /// </summary>
+    public void RemoveColor(EntityUid uid)
+    {
+        if (!TryComp<ColoredComponent>(uid, out var component))
+            return;
+
+        RemComp<ColoredComponent>(uid);
+    }
+
+    /// <summary>
+    /// Toggles coloring on/off without removing the component
+    /// </summary>
+    public void ToggleColoring(EntityUid uid, bool enabled)
+    {
+        if (!TryComp<ColoredComponent>(uid, out var component))
+            return;
+
+        component.Enabled = enabled;
+        Dirty(uid, component);
+        UpdateAppearance(uid, component);
+    }
+}

--- a/Content.Shared/Colored/ColoredComponent.cs
+++ b/Content.Shared/Colored/ColoredComponent.cs
@@ -1,0 +1,42 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared.Colored;
+
+/// <summary>
+/// Component that applies a simple color tint to an entity using a shader.
+/// Much simpler than the full paint system - just for basic coloring.
+/// </summary>
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true)]
+public sealed partial class ColoredComponent : Component
+{
+    /// <summary>
+    /// The color to apply to the entity
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public Color Color = Color.White;
+
+    /// <summary>
+    /// The original color before this component was added (used for restoration)
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public Color BeforeColor = Color.White;
+
+    /// <summary>
+    /// Whether the coloring is currently enabled
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool Enabled = true;
+
+    /// <summary>
+    /// The shader to use for coloring. Defaults to Greyscale which works well for recoloring.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public string ShaderName = "Greyscale";
+}
+
+[Serializable, NetSerializable]
+public enum ColoredVisuals : byte
+{
+    Colored,
+}

--- a/Content.Shared/Colored/SharedColoredSystem.cs
+++ b/Content.Shared/Colored/SharedColoredSystem.cs
@@ -1,0 +1,64 @@
+using Content.Shared.Examine;
+using Robust.Shared.Utility;
+
+namespace Content.Shared.Colored;
+
+public abstract class SharedColoredSystem : EntitySystem
+{
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<ColoredComponent, ComponentInit>(OnColoredInit);
+        SubscribeLocalEvent<ColoredComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnColoredInit(EntityUid uid, ColoredComponent component, ComponentInit args)
+    {
+        UpdateAppearance(uid, component);
+    }
+
+
+    private void OnExamined(EntityUid uid, ColoredComponent component, ExaminedEvent args)
+    {
+        if (component.Enabled && component.Color != Color.White)
+        {
+            var colorName = GetColorName(component.Color);
+            args.PushMarkup(Loc.GetString("colored-component-examine-colored", ("color", colorName)));
+        }
+    }
+
+
+    /// <summary>
+    /// Gets a human-readable name for a color
+    /// </summary>
+    private string GetColorName(Color color)
+    {
+        // Simple color name mapping - could be expanded
+        if (color.RByte == 255 && color.GByte == 0 && color.BByte == 0)
+            return "red";
+        if (color.RByte == 0 && color.GByte == 255 && color.BByte == 0)
+            return "green";
+        if (color.RByte == 0 && color.GByte == 0 && color.BByte == 255)
+            return "blue";
+        if (color.RByte == 255 && color.GByte == 255 && color.BByte == 0)
+            return "yellow";
+        if (color.RByte == 255 && color.GByte == 0 && color.BByte == 255)
+            return "magenta";
+        if (color.RByte == 0 && color.GByte == 255 && color.BByte == 255)
+            return "cyan";
+        if (color.RByte == 0 && color.GByte == 0 && color.BByte == 0)
+            return "black";
+
+        // Default to hex representation
+        return $"#{color.RByte:X2}{color.GByte:X2}{color.BByte:X2}".ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Updates the visual appearance of the colored entity
+    /// </summary>
+    public virtual void UpdateAppearance(EntityUid uid, ColoredComponent? component = null)
+    {
+        // Implementation in derived systems
+    }
+}

--- a/Resources/Locale/en-US/colored/colored.ftl
+++ b/Resources/Locale/en-US/colored/colored.ftl
@@ -1,0 +1,1 @@
+colored-component-examine-colored = It has been colored {$color}.

--- a/Resources/Prototypes/Entities/Colored/test_colored.yml
+++ b/Resources/Prototypes/Entities/Colored/test_colored.yml
@@ -1,0 +1,10 @@
+- type: entity
+  id: TestColoredEntity
+  name: test colored entity
+  description: A test entity for ColoredComponent functionality
+  components:
+  - type: Sprite
+    sprite: Objects/Tools/flashlight.rsi
+    state: flashlight
+  - type: Colored
+    color: "#50c878"


### PR DESCRIPTION
## About the PR
Added a lightweight ColoredComponent system that allows entities to be tinted with custom colors using shaders. This provides a simple alternative to the full paint system for basic entity coloring needs.

## Why / Balance
This system enables runtime entity coloring for customization purposes without the complexity of the full paint system. No balance impact as it's a purely visual/cosmetic system.

## Technical details
- **ColoredComponent**: Simple component with color, shader, and enabled state fields
- **ColoredVisualizerSystem**: Client-side system handling sprite shader application and equipment visual updates  
- **ColoredSystem**: Server-side system with helper methods (SetColor, RemoveColor, ToggleColoring)

## Media
Console example: `self spawn:in "head" "ClothingHeadHatCatEars" comp:ensure Colored do "vvwrite /entity/$ID/Colored/Color '#50c878'"`
<img width="229" height="160" alt="image" src="https://github.com/user-attachments/assets/eb98037e-ca40-4030-b6c9-2533bbf9ad6d" />


## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None.

**Changelog**
:cl:
- add: Added ColoredComponent system for simple entity coloring with shader support