### PR TITLE
Remove kippah items from loadouts and vending machines

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
@@ -24,7 +24,6 @@
     Urn: 5
     ClothingHeadHatKippahSimple: 3 #imp
     ClothingHeadHatKippahWhiteAndBlue: 1 #imp
-    ClothingHeadHatKippahBlueAndGold: 1 #imp
     Bible: 1
     SilverRing: 2 # DeltaV
     RingBox: 2 # DeltaV

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -40,7 +40,6 @@
   - ClothingNeckTransPin
   - ClothingNeckAutismPin
   - ClothingNeckGoldAutismPin
-  - ClothingHeadHatKippahBlueAndGold #imp
   - ClothingHeadHatKippahSimple #imp
   - ClothingHeadHatKippahWhiteAndBlue #imp
   - TowelColorBlack


### PR DESCRIPTION
## About the PR
Removes all three kippah variants from player loadouts and chapel vending machine inventory to address accessibility concerns.

## Why / Balance
Quick administrative fix to remove problematic items from normal gameplay access while preserving them for admin use if needed.

## Technical details
**Items removed from loadouts and vending:**
- ClothingHeadHatKippahBlueAndGold
- ClothingHeadHatKippahSimple  
- ClothingHeadHatKippahWhiteAndBlue

**Files changed:**
- `Resources/Prototypes/Loadouts/loadout_groups.yml` - Removed from player loadouts
- `Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml` - Removed from chapel vending

**Note:** The item prototypes still exist in `_Impstation/Entities/Clothing/Head/kippahs.yml` so admins can spawn them if needed.

## Media
Not applicable - administrative removal.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None. Items are simply no longer available through normal gameplay.

**Changelog**
:cl:
- remove: Removed kippah items from player loadouts and chapel vending machine
:cl: