### PR TITLE
Remove remaining kippah items from loadouts and vending

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml
@@ -22,8 +22,6 @@
     BoxCandle: 2
     BoxCandleSmall: 2
     Urn: 5
-    ClothingHeadHatKippahSimple: 3 #imp
-    ClothingHeadHatKippahWhiteAndBlue: 1 #imp
     Bible: 1
     SilverRing: 2 # DeltaV
     RingBox: 2 # DeltaV

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -40,8 +40,6 @@
   - ClothingNeckTransPin
   - ClothingNeckAutismPin
   - ClothingNeckGoldAutismPin
-  - ClothingHeadHatKippahSimple #imp
-  - ClothingHeadHatKippahWhiteAndBlue #imp
   - TowelColorBlack
   - TowelColorDarkBlue
   - TowelColorDarkGreen


### PR DESCRIPTION
## About the PR
Removes the remaining two kippah variants from player loadouts and chapel vending machine inventory to complete the kippah removal process.

## Why / Balance
Follow-up to PR #42 which only removed ClothingHeadHatKippahBlueAndGold. This PR removes the remaining two variants to complete the administrative fix.

## Technical details
**Items removed from loadouts and vending:**
- ClothingHeadHatKippahSimple
- ClothingHeadHatKippahWhiteAndBlue

**Files changed:**
- `Resources/Prototypes/Loadouts/loadout_groups.yml` - Removed from player loadouts
- `Resources/Prototypes/Catalog/VendingMachines/Inventories/chapel.yml` - Removed from chapel vending

**Note:** The item prototypes still exist in `_Impstation/Entities/Clothing/Head/kippahs.yml` so admins can spawn them if needed.

## Media
Not applicable - administrative removal.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None. Items are simply no longer available through normal gameplay.

**Changelog**
:cl:
- remove: Removed remaining kippah items from player loadouts and chapel vending machine
:cl: