### PR TITLE
Add QBPlaytest role timer override and update client title

### DIFF
--- a/Resources/ConfigPresets/QuantumBlue/quantumblue.toml
+++ b/Resources/ConfigPresets/QuantumBlue/quantumblue.toml
@@ -5,6 +5,7 @@ lobbyduration = 240
 round_end_pacifist = true
 round_restart_time = 300
 contraband_examine = false
+role_timer_override = "QBPlaytest"
 
 [movement]
 mob_pushing = false

--- a/Resources/manifest.yml
+++ b/Resources/manifest.yml
@@ -1,4 +1,4 @@
-﻿defaultWindowTitle: Delta-v
+﻿defaultWindowTitle: Quantum Blue
 windowIconSet: /Textures/Logo/icon
 splashLogo: /Textures/Logo/splashlogo.png
 


### PR DESCRIPTION
## About the PR
Added role timer override configuration for QBPlaytest and updated client window title branding.

## Why / Balance
This enables easier playtesting by bypassing role timers when using the QBPlaytest preset, and updates the client branding from Delta-V to Quantum Blue for proper identity.

## Technical details
- Added `role_timer_override = "QBPlaytest"` to QuantumBlue config preset
- Changed `defaultWindowTitle` from "Delta-v" to "Quantum Blue" in manifest.yml

## Media
N/A - Configuration changes only.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None.

**Changelog**
:cl:
- tweak: Updated client window title to "Quantum Blue"
- tweak: Added QBPlaytest role timer override to QuantumBlue config preset