### PR TITLE
Fix character customization preview clipping

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml
@@ -149,7 +149,7 @@
         </BoxContainer>
         <!-- Right side -->
         <BoxContainer Orientation="Vertical" VerticalExpand="True" VerticalAlignment="Center">
-            <SpriteView Name="SpriteView" Scale="8 8" Margin="4" SizeFlagsStretchRatio="1" />
+            <SpriteView Name="SpriteView" Scale="8 8" Margin="4" SizeFlagsStretchRatio="1" Stretch="Fill" />
             <BoxContainer Orientation="Horizontal" HorizontalAlignment="Center" Margin="0 5">
                 <Button Name="SpriteRotateLeft" Text="◀" StyleClasses="OpenRight" />
                 <cc:VSeparator Margin="2 0 3 0" />


### PR DESCRIPTION
## About the PR
Fixes character customization preview clipping by adding `Stretch="Fill"` to the character preview SpriteView. Large characters and extensive markings no longer clip outside the preview area.

## Why / Balance
This was a UI bug where characters with large markings or certain species would extend beyond the preview container bounds, making it difficult to see the full character during customization. This fix improves the user experience without affecting game balance.

## Technical details
- Added `Stretch="Fill"` attribute to SpriteView in `Content.Client/Lobby/UI/HumanoidProfileEditor.xaml`
- Characters now automatically scale to fit within container bounds

## Media
<img width="259" height="487" alt="Screenshot 2025-09-28 174100" src="https://github.com/user-attachments/assets/9c5789c2-3714-4701-8ae5-35a73cf8073c" />


## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- fix: Fixed character customization preview clipping for large characters and markings