### PR TITLE
Fix dirt tile RSIC serialization

### DIFF
--- a/Resources/Prototypes/Tiles/planet.yml
+++ b/Resources/Prototypes/Tiles/planet.yml
@@ -1,7 +1,7 @@
 - type: tile
   id: FloorPlanetDirt
   name: tiles-dirt-floor
-  sprite: { sprite: /Textures/Tiles/Planet/dirt.rsi, state: dirt }
+  sprite: /Textures/Tiles/Planet/dirt.rsi/dirt.png
   variants: 4
   placementVariants:
   - 1.0

--- a/Resources/Textures/Tiles/Planet/dirt.rsi/meta.json
+++ b/Resources/Textures/Tiles/Planet/dirt.rsi/meta.json
@@ -6,6 +6,7 @@
     "x": 32,
     "y": 32
   },
+  "rsic": false,
   "states": [
     {
       "name": "dirt"


### PR DESCRIPTION
## About the PR
Fixed YAML linter errors for dirt tile by disabling RSIC packaging and using direct path format to match wizden configuration.

## Why / Balance
Resolves linter failures that were preventing CI from passing. No gameplay impact.

## Technical details
- Added `"rsic": false` to dirt.rsi metadata to disable RSIC packaging
- Reverted dirt tile definition to use direct path format: `/Textures/Tiles/Planet/dirt.rsi/dirt.png`

## Media
N/A - Technical fix only

## Requirements
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- fix: Fixed YAML linter errors for dirt tiles