### PR TITLE
Slime punches deal caustic

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -126,6 +126,17 @@
   - type: FootPrints # DeltaV port from EE, blood splatter
     leftBarePrint: "footprint-left-bare-slime"
     rightBarePrint: "footprint-right-bare-slime"
+  # QB: Blame matt, he thinks its funny
+  - type: MeleeWeapon
+    soundHit:
+      collection: Punch
+    angle: 30
+    animation: WeaponArcFist
+    attackRate: 1
+    damage:
+      types:
+        Blunt: 2.5
+        Caustic: 2.5
 
 - type: entity
   parent: MobHumanDummy


### PR DESCRIPTION
Matt will burn for this

## About the PR
<!-- What did you change? -->
Slime people now do 2.5 blunt and 2.5 caustic whenever they punch people (Was 5 blunt, 0 caustic before)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I don't know, Matt is as sick and twisted trickster god

## Technical details
Added a MeleeWeapon component to BaseMobSlimePerson in Prototypes/Entities/Mobs/Species/slime.yml that overrides the parent one and has different damage values.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc).
Small fixes/refactors are exempt. -->
<img width="499" height="366" alt="matt_is_evil" src="https://github.com/user-attachments/assets/a9605962-acbd-43eb-810e-e060ed463b79" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have tested all added content and changes.
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to take this Changelog template out of the comment block in order for it to show up.~~~~
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- tweak: Slime punches now do less blunt, and more caustic! Blame MattFright! (2.5 blunt and 2.5 caustic. Was previously 5 blunt and 0 caustic)
