### PR TITLE
Add game.pauseonstart CVar

### DIFF
--- a/Content.Server/GameTicking/GameTicker.CVars.cs
+++ b/Content.Server/GameTicking/GameTicker.CVars.cs
@@ -18,6 +18,9 @@ namespace Content.Server.GameTicking
         [ViewVariables]
         public bool DisallowLateJoin { get; private set; } = false;
 
+        [ViewVariables] // QuantumBlue
+        public bool PauseOnStart { get; private set; } = false; // QuantumBlue
+
         [ViewVariables]
         public string? ServerName { get; private set; }
 
@@ -49,6 +52,7 @@ namespace Content.Server.GameTicking
             }, true);
             Subs.CVar(_cfg, CCVars.GameDummyTicker, value => DummyTicker = value, true);
             Subs.CVar(_cfg, CCVars.GameLobbyDuration, value => LobbyDuration = TimeSpan.FromSeconds(value), true);
+            Subs.CVar(_cfg, CCVars.GamePauseOnStart, value => PauseOnStart = value, true); // QuantumBlue
             Subs.CVar(_cfg, CCVars.GameDisallowLateJoins,
                 value => { DisallowLateJoin = value; UpdateLateJoinStatus(); }, true);
             Subs.CVar(_cfg, CCVars.AdminLogsServerName, value =>

--- a/Content.Server/GameTicking/GameTicker.cs
+++ b/Content.Server/GameTicking/GameTicker.cs
@@ -111,6 +111,11 @@ namespace Content.Server.GameTicking
             if (!DummyTicker)
                 RestartRound();
 
+            // QuantumBlue - Pause countdown on server startup if configured
+            if (PauseOnStart && LobbyEnabled)
+                PauseStart(true);
+            // End QuantumBlue
+
             _postInitialized = true;
         }
 

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -23,6 +23,12 @@ public sealed partial class CCVars
     public static readonly CVarDef<int>
         GameLobbyDuration = CVarDef.Create("game.lobbyduration", 150, CVar.ARCHIVE);
 
+    /// <summary> // QuantumBlue
+    ///     If true, the lobby countdown will start paused on server startup.
+    /// </summary>
+    public static readonly CVarDef<bool>
+        GamePauseOnStart = CVarDef.Create("game.pauseonstart", false, CVar.ARCHIVE | CVar.SERVERONLY); // QuantumBlue
+
     /// <summary>
     ///     Controls if players can latejoin at all.
     /// </summary>


### PR DESCRIPTION
## About the PR
Adds a new CVar `game.pauseonstart` that pauses the lobby countdown on server startup.

## Why / Balance
This is useful for development, testing, and playtest environments where the server isn't active most of the time and you want to prevent the round from starting automatically when the server boots up. Admins can use the `delaystart` command to unpause when ready.

## Technical details
- Adds `game.pauseonstart` CVar (defaults to false)

## Media
N/A - Server configuration feature only

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None