### PR TITLE
Add server logging for AHelps

### DIFF
--- a/Content.Server/Administration/Systems/BwoinkSystem.cs
+++ b/Content.Server/Administration/Systems/BwoinkSystem.cs
@@ -1053,6 +1053,32 @@ namespace Content.Server.Administration.Systems
             return _recentMessages;
         }
         // End Starlight Changes
+
+        // Begin QuantumBlue - Log AHelps to server logs for audit trail
+        protected override void LogBwoink(BwoinkTextMessage message)
+        {
+            // Strip markup from formatted text
+            var cleanText = FormattedMessage.RemoveMarkupPermissive(message.Text);
+
+            // Look up usernames (fall back to NetUserId if offline)
+            var senderName = _playerManager.TryGetSessionById(message.TrueSender, out var senderSession)
+                ? senderSession.Name
+                : message.TrueSender.UserId.ToString();
+
+            var recipientName = _playerManager.TryGetSessionById(message.UserId, out var recipientSession)
+                ? recipientSession.Name
+                : message.UserId.UserId.ToString();
+
+            // Build flags string
+            var flags = new List<string>();
+            if (message.AdminOnly) flags.Add("ADMIN-ONLY");
+            if (!message.PlaySound) flags.Add("SILENT");
+            var flagsStr = flags.Count > 0 ? $" [{string.Join(", ", flags)}]" : "";
+
+            // Log in clean format
+            _sawmill.Info($"AHELP: {senderName} -> {recipientName}{flagsStr}: {cleanText}");
+        }
+        // End QuantumBlue
     }
 
     public sealed class AHelpMessageParams

--- a/Content.Shared/Administration/SharedBwoinkSystem.cs
+++ b/Content.Shared/Administration/SharedBwoinkSystem.cs
@@ -21,7 +21,7 @@ namespace Content.Shared.Administration
             // Specific side code in target.
         }
 
-        protected void LogBwoink(BwoinkTextMessage message)
+        protected virtual void LogBwoink(BwoinkTextMessage message) // QuantumBlue - Changed to virtual to allow override
         {
         }
 


### PR DESCRIPTION
## About the PR
Implements server-side logging for all AHelp (admin help) messages. Previously, AHelps were only stored in memory and optionally relayed to Discord webhooks with no permanent server-side record.

## Why / Balance
Provides a permanent audit trail of all admin help interactions for server administration purposes. This does not affect gameplay or balance.

## Technical details
- Made `LogBwoink()` virtual in SharedBwoinkSystem to allow override
- Implemented logging in BwoinkSystem using the existing AHELP sawmill
- Logs are stripped of markup and include sender/recipient names and message flags

## Media
N/A - Internal logging feature with no visible ingame changes.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None.

**Changelog**
<!-- No changelog needed - internal admin tooling change -->