### PR TITLE
testlist fix + cargoassistant fix

### DIFF
--- a/Content.IntegrationTests/Tests/PostMapInitTest.cs
+++ b/Content.IntegrationTests/Tests/PostMapInitTest.cs
@@ -65,6 +65,7 @@ namespace Content.IntegrationTests.Tests
             "MeteorArena",
             "Pebble", // DeltaV
             "Edge", // DeltaV
+			"Train", // Imp
             "Shoukou", // DeltaV
             "Tortuga", // DeltaV
             "Terra", //DeltaV

--- a/Resources/Prototypes/Maps/train.yml
+++ b/Resources/Prototypes/Maps/train.yml
@@ -18,7 +18,7 @@
             !type:NanotrasenNameGenerator
             prefixCreator: 'DV'
         - type: StationJobs
-          availableJobs: # Max of 76 inc. latejoins and trainees.
+          availableJobs: # Max of 78 inc. latejoins and trainees.
             # command - 3
             AdministrativeAssistant: [ 1, 1 ]
             Captain: [ 1, 1 ]
@@ -65,11 +65,11 @@
             Brigmedic: [ 1, 1 ]
             SecurityCadet: [ 3, 3 ]
             SecurityOfficer: [ 5, 5 ]
-            # supply 9
+            # supply 11
             Quartermaster: [ 1, 1 ]
-            Courier: [ 1, 1 ]
+            Courier: [ 1, 2 ]
             SalvageSpecialist: [ 3, 3 ]
             CargoTechnician: [ 3, 3 ]
-            SupplyAssistant: [ 1, 1 ]
+            CargoAssistant: [ 1, 2 ]
             # civilian
             Passenger: [ -1, -1 ]


### PR DESCRIPTION
## About the PR
Problem:
- SupplyAssistant job prototype doesn't exist
- No test case in PostMapInitTest.cs
Fixed:
**SupplyAssistant** changed to **CargoAssistant** in train's job count file, also very slightly tweaked cargo jobcounts (they have less than sec somehow) 1 more courier and 1 more cargo assistant role
The map test list file has been was lacking a line for train, I added one so this should fix it

## Why / Balance
Minor error fixes
Cargo was slightly under-staffed and only had 1 courier job and 1 cargoassistant job, 1 late join to each respectively should be a little better

## Technical details
**Resources/Prototypes/Maps/train.yml** had **SupplyAssistant** -> **CargoAssistant**
**Content.IntegrationTests/Tests/PostMapInitTest.cs** has a list of maps for testing, train was not there, added a line for it

## Media
Too small a change for that, no visible ingame changes

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None so far, await followup

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to take this Changelog template out of the comment block in order for it to show up.~~~~
Changelogs must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- fix: Fixed cargoassistant job ID mismatch from imp's supplyassistant
- fix: Fixed train's missing entry in map test list
- tweak: Added 1 extra latejoin to cargoassistant and courier on train
-->
