### PR TITLE
Add emotes and radio to Clippy

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/_NF/Entities/Mobs/NPCs/pets.yml
@@ -3,7 +3,7 @@
   abstract: true
   components:
   - type: GhostRole
-#  - type: IntrinsicRadioReceiver # DeltaV - comment out
+  - type: IntrinsicRadioReceiver # QB - Uncommented for radio functionality
   - type: CargoSellBlacklist
 
 - type: entity
@@ -17,6 +17,10 @@
     description: ghost-role-information-deltav-clippy-description # DeltaV - Alternate Description
     rules: ghost-role-information-nonantagonist-rules
 #    prototype: CatClippy # DeltaV - Comment out
+  - type: Speech # QB - Add emotes for Clippy
+    speechSounds: Cat
+    speechVerb: SmallMob
+    allowedEmotes: ['Meow', 'Hiss', 'Mew', 'Purr', 'Growl']
   - type: Loadout
     prototypes: [ MobClippyGear ]
   - type: RandomMetadata
@@ -30,14 +34,14 @@
     - id: FoodMeatCat
       amount: 1
 #    - id: MaterialHideClippy
-#  - type: IntrinsicRadioTransmitter # DeltaV - Comment out Radio Channels
-#    channels:
-#    - Service
-#  - type: ActiveRadio
-#    channels:
-#    - Service 
+  - type: IntrinsicRadioTransmitter # QB - Uncommented and changed to Supply for mail/logistics
+    channels:
+    - Supply
+  - type: ActiveRadio
+    channels:
+    - Supply
   - type: NpcFactionMember
     factions:
       - Cat
       - PetsNT
-#  - type: ShowJobIcons # DeltaV - Comment out
+  - type: ShowJobIcons

--- a/Resources/Prototypes/_NF/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_NF/Voice/speech_emote_sounds.yml
@@ -1,9 +1,19 @@
 - type: emoteSounds
   id: Cat
-  sound:
-    path: /Audio/Animals/cat_meow.ogg
-    params:
-      variation: 0.125
+  params:
+    variation: 0.125
+  # QB - Add specific sounds for each emote
+  sounds:
+    Meow:
+      collection: FelinidMeows
+    Hiss:
+      collection: FelinidHisses
+    Mew:
+      collection: FelinidMews
+    Growl:
+      collection: FelinidGrowls
+    Purr:
+      collection: FelinidPurrs
 
 - type: emoteSounds
   id: NfsdCat


### PR DESCRIPTION
## About the PR
Enables Clippy (the mail/logistics cat ghost role) to use emotes and radio communication.

## Why / Balance
Clippy was missing emotes that other cat ghost roles have, making the role less interactive. Additionally, Clippy's radio functionality was commented out, preventing them from receiving mail notifications on the Supply channel.

## Technical details
- Added Speech component with allowedEmotes: ['Meow', 'Hiss', 'Mew', 'Purr', 'Growl']
- Uncommented IntrinsicRadioReceiver in NFMobPet parent entity
- Uncommented IntrinsicRadioTransmitter and ActiveRadio components
- Changed radio channel from Service to Supply (for mail notifications)
- Uncommented ShowJobIcons component

## Media
N/A
Tested live during playtests.

## Requirements
- [X] I have tested all added content and changes.
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- fix: Clippy can now use cat emotes (Meow, Hiss, Mew, Purr, Growl)
- fix: Clippy can now receive mail notifications via Supply radio channel